### PR TITLE
Add format to capture non-english spelling of bad-usernames

### DIFF
--- a/disallowed_usernames.csv
+++ b/disallowed_usernames.csv
@@ -1,6 +1,7 @@
 activate
 admin
 administrator
+:fr:administrateur
 android
 api
 bad


### PR DESCRIPTION
if example.com/admin is bad then example.co.fr/administrateur will hurt as
well.  So I suggest a format of :tlcc:<word> where tlcc is the country code
as used in the DNS system.  I have also rather petulantly removed spaces
from the csv file. Sorry about that.
