### PR TITLE
add .well-known

### DIFF
--- a/disallowed usernames.csv
+++ b/disallowed usernames.csv
@@ -1,5 +1,6 @@
 .json,
 .rss,
+.well-known,
 .xml,
 about,
 access,


### PR DESCRIPTION
anybody who can control files at /.well-known/ on your domain can make LetsEncrypt issue certificates for your domain